### PR TITLE
feature: キーワードエリア実装とメインコンテンツの全体レイアウト

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,7 +375,7 @@
             </ol>
         </section>
 
-        <main>
+        <main class="content">
             <section class="new-pressrelease">
                 <h2 class="new-pressrelease__head2">
                     新着プレスリリース
@@ -556,6 +556,48 @@
                     </button>
                 </div>
 
+            </section>
+            <section class="keyword-section">
+                <h2 class="keyword-section__head2">
+                    今注目のキーワード
+                </h2>
+                <ul class="keyword__list">
+                    <li class="keyword__word">
+                        <a href="#">
+                            キーワード
+                        </a>
+                    </li>
+                    <li class="keyword__word">
+                        <a href="#">
+                            キーワード
+                        </a>
+                    </li>
+                    <li class="keyword__word">
+                        <a href="#">
+                            キーワード
+                        </a>
+                    </li>
+                    <li class="keyword__word">
+                        <a href="#">
+                            キーワード
+                        </a>
+                    </li>
+                    <li class="keyword__word">
+                        <a href="#">
+                            キーワード
+                        </a>
+                    </li>
+                    <li class="keyword__word">
+                        <a href="#">
+                            キーワード
+                        </a>
+                    </li>
+                    <li class="keyword__word keyword__more">
+                        <a href="#">
+                            もっと見る
+                        </a>
+                    </li>
+                </ul>
             </section>
         </main>
     </div>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
                             </ul>
                         </nav>
                         <form class="header__search">
-                            <input type="text" name="search_word" placeholder="キーワードで検索" title="検索キーワードを入力する" class="">
+                            <input type="search" name="search_word" placeholder="キーワードで検索" title="検索キーワードを入力する">
                             <button type="submit" title="検索">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
                                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/index.html
+++ b/index.html
@@ -557,7 +557,7 @@
                 </div>
 
             </section>
-            <section class="keyword-section">
+            <aside class="keyword-section">
                 <h2 class="keyword-section__head2">
                     今注目のキーワード
                 </h2>
@@ -598,7 +598,7 @@
                         </a>
                     </li>
                 </ul>
-            </section>
+            </aside>
         </main>
     </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -374,6 +374,190 @@
                 </li>
             </ol>
         </section>
+
+        <main>
+            <section class="new-pressrelease">
+                <h2 class="new-pressrelease__head2">
+                    新着プレスリリース
+                </h2>
+                <div class="new-pressrelease__list-wrap">
+                    <ul class="new-pressrelease__list">
+                        <li>
+                            <article class="new-pressrelease-article">
+                                <a href="#" class="new-pressrelease-article__link"
+                                    title="記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル">
+                                    <div class="new-pressrelease-article__title-group">
+                                        <h3 class="new-pressrelease-article__title">
+                                            記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル
+                                        </h3>
+
+                                    </div>
+                                    <img src="image/スクリーンショット 2019-06-03 17.27.jpg" alt="記事のタイトル" width="100"
+                                        height="66">
+                                </a>
+                                <span class="new-pressrelease-article__time">
+                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+                                        class="new-pressrelease-article__time-icon">
+                                        <circle cx="12" cy="12" r="11.5">
+                                        </circle>
+                                        <path d="M11.2 5.6V13.6H16.8"></path>
+                                    </svg>
+                                    <!-- datatimeの値は適当 -->
+                                    <time datetime="2024-05-08T14:54:39.929+09:00">10分前</time>
+                                    <a href="#" class="">
+                                        <p class="new-pressrelease-article__company_name">BRITA Japan株式会社</p>
+                                    </a>
+                                </span>
+                            </article>
+                        </li>
+                        <li>
+                            <article class="new-pressrelease-article">
+                                <a href="#" class="new-pressrelease-article__link"
+                                    title="記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル">
+                                    <div class="new-pressrelease-article__title-group">
+                                        <h3 class="new-pressrelease-article__title">
+                                            短いタイトル
+                                        </h3>
+
+                                    </div>
+                                    <img src="image/スクリーンショット 2019-06-03 17.27.jpg" alt="記事のタイトル" width="100"
+                                        height="66">
+                                </a>
+                                <span class="new-pressrelease-article__time">
+                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+                                        class="new-pressrelease-article__time-icon">
+                                        <circle cx="12" cy="12" r="11.5">
+                                        </circle>
+                                        <path d="M11.2 5.6V13.6H16.8"></path>
+                                    </svg>
+                                    <!-- datatimeの値は適当 -->
+                                    <time datetime="2024-05-08T14:54:39.929+09:00">10分前</time>
+                                    <a href="#" class="">
+                                        <p class="new-pressrelease-article__company_name">BRITA Japan株式会社</p>
+                                    </a>
+                                </span>
+                            </article>
+                        </li>
+                        <li>
+                            <article class="new-pressrelease-article">
+                                <a href="#" class="new-pressrelease-article__link"
+                                    title="記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル">
+                                    <div class="new-pressrelease-article__title-group">
+                                        <h3 class="new-pressrelease-article__title">
+                                            記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル
+                                        </h3>
+
+                                    </div>
+                                    <img src="image/スクリーンショット 2019-06-03 17.27.jpg" alt="記事のタイトル" width="100"
+                                        height="66">
+                                </a>
+                                <span class="new-pressrelease-article__time">
+                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+                                        class="new-pressrelease-article__time-icon">
+                                        <circle cx="12" cy="12" r="11.5">
+                                        </circle>
+                                        <path d="M11.2 5.6V13.6H16.8"></path>
+                                    </svg>
+                                    <!-- datatimeの値は適当 -->
+                                    <time datetime="2024-05-08T14:54:39.929+09:00">10分前</time>
+                                    <a href="#" class="">
+                                        <p class="new-pressrelease-article__company_name">BRITA Japan株式会社</p>
+                                    </a>
+                                </span>
+                            </article>
+                        </li>
+                        <li>
+                            <article class="new-pressrelease-article">
+                                <a href="#" class="new-pressrelease-article__link"
+                                    title="記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル">
+                                    <div class="new-pressrelease-article__title-group">
+                                        <h3 class="new-pressrelease-article__title">
+                                            記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル
+                                        </h3>
+
+                                    </div>
+                                    <img src="image/スクリーンショット 2019-06-03 17.27.jpg" alt="記事のタイトル" width="100"
+                                        height="66">
+                                </a>
+                                <span class="new-pressrelease-article__time">
+                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+                                        class="new-pressrelease-article__time-icon">
+                                        <circle cx="12" cy="12" r="11.5">
+                                        </circle>
+                                        <path d="M11.2 5.6V13.6H16.8"></path>
+                                    </svg>
+                                    <!-- datatimeの値は適当 -->
+                                    <time datetime="2024-05-08T14:54:39.929+09:00">10分前</time>
+                                    <a href="#" class="">
+                                        <p class="new-pressrelease-article__company_name">BRITA Japan株式会社</p>
+                                    </a>
+                                </span>
+                            </article>
+                        </li>
+                        <li>
+                            <article class="new-pressrelease-article">
+                                <a href="#" class="new-pressrelease-article__link"
+                                    title="記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル">
+                                    <div class="new-pressrelease-article__title-group">
+                                        <h3 class="new-pressrelease-article__title">
+                                            記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル
+                                        </h3>
+
+                                    </div>
+                                    <img src="image/スクリーンショット 2019-06-03 17.27.jpg" alt="記事のタイトル" width="100"
+                                        height="66">
+                                </a>
+                                <span class="new-pressrelease-article__time">
+                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+                                        class="new-pressrelease-article__time-icon">
+                                        <circle cx="12" cy="12" r="11.5">
+                                        </circle>
+                                        <path d="M11.2 5.6V13.6H16.8"></path>
+                                    </svg>
+                                    <!-- datatimeの値は適当 -->
+                                    <time datetime="2024-05-08T14:54:39.929+09:00">10分前</time>
+                                    <a href="#" class="">
+                                        <p class="new-pressrelease-article__company_name">BRITA Japan株式会社</p>
+                                    </a>
+                                </span>
+                            </article>
+                        </li>
+                        <li>
+                            <article class="new-pressrelease-article">
+                                <a href="#" class="new-pressrelease-article__link"
+                                    title="記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル">
+                                    <div class="new-pressrelease-article__title-group">
+                                        <h3 class="new-pressrelease-article__title">
+                                            記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル記事のタイトル
+                                        </h3>
+
+                                    </div>
+                                    <img src="image/スクリーンショット 2019-06-03 17.27.jpg" alt="記事のタイトル" width="100"
+                                        height="66">
+                                </a>
+                                <span class="new-pressrelease-article__time">
+                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+                                        class="new-pressrelease-article__time-icon">
+                                        <circle cx="12" cy="12" r="11.5">
+                                        </circle>
+                                        <path d="M11.2 5.6V13.6H16.8"></path>
+                                    </svg>
+                                    <!-- datatimeの値は適当 -->
+                                    <time datetime="2024-05-08T14:54:39.929+09:00">10分前</time>
+                                    <a href="#" class="">
+                                        <p class="new-pressrelease-article__company_name">BRITA Japan株式会社</p>
+                                    </a>
+                                </span>
+                            </article>
+                        </li>
+                    </ul>
+                    <button type="button" class="new-pressrelease__more">
+                        もっと見る
+                    </button>
+                </div>
+
+            </section>
+        </main>
     </div>
 </body>
 

--- a/style.css
+++ b/style.css
@@ -6,6 +6,8 @@
 
   --primary-color: #24426f;
   --secondary-color: #3081c9;
+  --secondary-500-color: #4b98d6;
+  --secondary-700-color: #3879b7;
   --white-color: #ffffff;
   --gray-color: #a2a2a2;
   --black-color: #000000;
@@ -344,10 +346,14 @@ a:visited {
       width: 110px;
       height: 37px;
       color: var(--white-color);
-      background-color: var(--secondary-color);
+      background-color: var(--secondary-700-color);
       border: none;
       border-radius: 3px;
       box-shadow: 0 1px 2px var(--black-color);
+      cursor: pointer;
+    }
+    .new-pressrelease__more:hover {
+      background-color: var(--secondary-500-color);
     }
   }
 }

--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@
   --standard-font-size: 13px;
   --sm-font-size: 12px;
   --lg-font-size: 14px;
+  --xl-font-size: 18px;
   --xxl-font-size: 24px;
 
   --primary-color: #24426f;
@@ -10,7 +11,9 @@
   --secondary-700-color: #3879b7;
   --white-color: #ffffff;
   --gray-color: #a2a2a2;
+  --gray-white-color: #f1f1f1;
   --black-color: #000000;
+  --black-light-color: #3b3b3b;
 }
 
 body {
@@ -320,7 +323,7 @@ a:visited {
   .new-pressrelease__head2 {
     font-size: var(--xxl-font-size);
     font-weight: bold;
-    margin: 10px 0;
+    margin: 0;
   }
 
   h3 {
@@ -428,10 +431,61 @@ a:visited {
   display: block;
   height: 0;
   width: 380px;
-  border-bottom: 1px solid var(--gray-color);
+  border-bottom: 1px solid var(--gray-white-color);
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
   margin: auto;
+}
+
+.keyword-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  height: fit-content;
+  padding-bottom: 40px;
+  border-bottom: 1px solid var(--gray-white-color);
+
+  .keyword-section__head2 {
+    font-size: var(--xl-font-size);
+    font-weight: bold;
+    margin: 0;
+  }
+}
+
+.keyword__list {
+  display: flex;
+  flex-wrap: wrap;
+  width: 308px;
+  row-gap: 9px;
+  column-gap: 12px;
+  margin: 0;
+  color: var(--black-light-color);
+
+  .keyword__word {
+    font-size: var(--sm-font-size);
+    background-color: var(--gray-white-color);
+    padding: 1px 8px;
+    border-radius: 14px;
+    width: fit-content;
+    height: fit-content;
+  }
+  .keyword__word:hover {
+    color: var(--black-color);
+  }
+
+  .keyword__more {
+    background-color: var(--white-color);
+    border: 1px solid var(--gray-white-color);
+  }
+  .keyword__more:hover {
+    color: var(--secondary-color);
+  }
+}
+
+.content {
+  display: flex;
+  justify-content: center;
+  margin: 30px auto;
 }

--- a/style.css
+++ b/style.css
@@ -2,11 +2,12 @@
   --standard-font-size: 13px;
   --sm-font-size: 12px;
   --lg-font-size: 14px;
+  --xxl-font-size: 24px;
 
   --primary-color: #24426f;
   --secondary-color: #3081c9;
   --white-color: #ffffff;
-  --gray-color: #6d6d6d;
+  --gray-color: #a2a2a2;
   --black-color: #000000;
 }
 
@@ -307,4 +308,124 @@ a:visited {
       }
     }
   }
+}
+
+.new-pressrelease {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+
+  .new-pressrelease__head2 {
+    font-size: var(--xxl-font-size);
+    font-weight: bold;
+    margin: 10px 0;
+  }
+
+  h3 {
+    margin: 0;
+  }
+  p {
+    margin: 0;
+  }
+
+  .new-pressrelease__list-wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    .new-pressrelease__list {
+      display: flex;
+      flex-wrap: wrap;
+      column-gap: 20px;
+      max-width: 800px;
+    }
+
+    .new-pressrelease__more {
+      width: 110px;
+      height: 37px;
+      color: var(--white-color);
+      background-color: var(--secondary-color);
+      border: none;
+      border-radius: 3px;
+      box-shadow: 0 1px 2px var(--black-color);
+    }
+  }
+}
+
+.new-pressrelease-article {
+  width: 380px;
+  height: fit-content;
+  gap: 8px;
+  padding: 16px 0;
+  position: relative;
+  margin: 0;
+  padding-bottom: 10px;
+  text-align: center;
+
+  display: flex;
+  flex-direction: column;
+
+  .new-pressrelease-article__link {
+    display: flex;
+    justify-content: space-between;
+
+    .new-pressrelease-article__title-group {
+      display: flex;
+      flex-direction: column;
+      align-items: start;
+      justify-content: space-between;
+      height: 70px;
+
+      gap: 4px;
+      /* title */
+      .new-pressrelease-article__title {
+        font-size: var(--lg-font-size);
+        font-weight: normal;
+        display: -webkit-box;
+        overflow: hidden;
+        line-break: normal;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+      }
+      .new-pressrelease-article__title:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+  /* publish datetime */
+  .new-pressrelease-article__time {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    color: var(--gray-color);
+    font-size: var(--sm-font-size);
+
+    .new-pressrelease-article__time-icon {
+      stroke: var(--gray-color);
+    }
+  }
+  .new-pressrelease-article__link:hover {
+    color: var(--secondary-color);
+  }
+  /* company name */
+  .new-pressrelease-article__company_name {
+    color: var(--gray-color);
+    font-size: var(--sm-font-size);
+    padding-left: 8px;
+  }
+  .new-pressrelease-article__company_name:hover {
+    color: var(--black-color);
+  }
+}
+.new-pressrelease-article::before {
+  content: "";
+  display: block;
+  height: 0;
+  width: 380px;
+  border-bottom: 1px solid var(--gray-color);
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: auto;
 }


### PR DESCRIPTION
## FIgma

https://www.figma.com/file/oN6dHmudZv11PwzAqevkZT/TOP?type=design&node-id=6-0&mode=design&t=yNgjymfduAwInzN0-0

## Overview

実装したもの
- キーワードエリアと新着プレスリリース含めた全体レイアウト調整
![image](https://github.com/Romira915/training-html-css/assets/40430090/c0b66248-1323-4416-b655-5619a6a1ed15)
